### PR TITLE
requirePermission should check for fully-qualified name.

### DIFF
--- a/src/main/java/de/philworld/bukkit/compassex/Component.java
+++ b/src/main/java/de/philworld/bukkit/compassex/Component.java
@@ -28,7 +28,7 @@ abstract class Component {
 	}
 
 	protected static void requirePermission(Player p, String permission) throws PermissionException {
-		if (!p.hasPermission(permission))
+		if (!p.hasPermission("compassex." + permission))
 			throw new PermissionException();
 	}
 


### PR DESCRIPTION
The documentation shows sensible names like compassex.here,
compassex.bed etc, but I was finding that I got permission errors if I
added those permissions (in GroupManager) as directed; they went away if
I instead gave just "here", "bed" etc.

This change should fix that, by automatically prepending "compassex.".