### PR TITLE
Tell deserialiser about BlockLocation when parsing deathpoints.db.yml too #25

### DIFF
--- a/src/main/java/de/philworld/bukkit/compassex/DeathpointComponent.java
+++ b/src/main/java/de/philworld/bukkit/compassex/DeathpointComponent.java
@@ -10,6 +10,7 @@ import java.util.logging.Level;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.configuration.serialization.ConfigurationSerialization;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -42,6 +43,8 @@ public class DeathpointComponent extends Component implements Listener, Persista
 		File f = new File(plugin.getDataFolder(), "deathpoints.db.yml");
 		if (!f.exists())
 			return;
+                // hopefully fix https://github.com/Philipp15b/CompassEx/issues/25
+                ConfigurationSerialization.registerClass(BlockLocation.class);
 		YamlConfiguration config = YamlConfiguration.loadConfiguration(f);
 		for (String player : config.getKeys(false)) {
 			deathPoints.put(player, (BlockLocation) config.get(player));


### PR DESCRIPTION
Same fix as a361c42, but for the problem reported in #25 - a crash parsing deathpoints.db.yml of the form:

```
[20:18:01] [Server thread/INFO]: [CompassEx] Enabling CompassEx v3.1.0*
[20:18:01] [Server thread/ERROR]: Error occurred while enabling CompassEx v3.1.0 (Is it up to date?)
org.yaml.snakeyaml.error.YAMLException: Could not deserialize object
        at org.bukkit.configuration.file.YamlConstructor$ConstructCustomObject.construct(YamlConstructor.java:50) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObjectNoCheck(BaseConstructor.java:270) ~[snakeyaml-1.33.jar:?]
        at org.yaml.snakeyaml.constructor.BaseConstructor.constructObject(BaseConstructor.java:253) ~[snakeyaml-1.33.jar:?]
        at org.bukkit.configuration.file.YamlConstructor.construct(YamlConstructor.java:27) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.YamlConfiguration.fromNodeTree(YamlConfiguration.java:160) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.YamlConfiguration.loadFromString(YamlConfiguration.java:117) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.FileConfiguration.load(FileConfiguration.java:160) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.FileConfiguration.load(FileConfiguration.java:128) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.YamlConfiguration.loadConfiguration(YamlConfiguration.java:306) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at de.philworld.bukkit.compassex.DeathpointComponent.load(DeathpointComponent.java:42) ~[CompassEx-3.1.0.jar:?]
        at de.philworld.bukkit.compassex.DeathpointComponent.<init>(DeathpointComponent.java:35) ~[CompassEx-3.1.0.jar:?]
        at de.philworld.bukkit.compassex.CompassEx.onEnable(CompassEx.java:43) ~[CompassEx-3.1.0.jar:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:371) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:544) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R2.CraftServer.enablePlugin(CraftServer.java:578) ~[paper-1.19.3.jar:git-Paper-371]
        at org.bukkit.craftbukkit.v1_19_R2.CraftServer.enablePlugins(CraftServer.java:492) ~[paper-1.19.3.jar:git-Paper-371]
        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:635) ~[paper-1.19.3.jar:git-Paper-371]
        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:434) ~[paper-1.19.3.jar:git-Paper-371]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:301) ~[paper-1.19.3.jar:git-Paper-371]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1101) ~[paper-1.19.3.jar:git-Paper-371]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[paper-1.19.3.jar:git-Paper-371]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
Caused by: java.lang.IllegalArgumentException: Specified class does not exist ('de.philworld.bukkit.compassex.util.BlockLocation')
        at org.bukkit.configuration.serialization.ConfigurationSerialization.deserializeObject(ConfigurationSerialization.java:197) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.configuration.file.YamlConstructor$ConstructCustomObject.construct(YamlConstructor.java:48) ~[paper-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        ... 22 more
[20:18:01] [Server thread/INFO]: [CompassEx] Disabling CompassEx v3.1.0
```

It comes about when `deathpoints.db.yml` contains entries like:

```yaml
[davidp@headshrinker:/opt/msm/servers/The-Wild/plugins]$ cat CompassEx/deathpoints.db.yml 
bigpresh:
  ==: de.philworld.bukkit.compassex.util.BlockLocation
  world: world
  x: 229097
  y: 63
  z: -139353
```

Fixes #25 at least for me!